### PR TITLE
Update abandoned_invariants.md

### DIFF
--- a/abandoned_invariants.md
+++ b/abandoned_invariants.md
@@ -55,7 +55,7 @@ instanceOf operator used to be a reliable way to .
 
 ## Breakage
 
-Introduction of symbols.
+Introduction of `Symbol.hasInstance`.
 
 ### Specification Details
 
@@ -73,11 +73,11 @@ TODO
 
 ### Description
 
-toString used to be a brand check.
+toString used to be a brand check. That `Symbol.toStringTag` would remove this invariant  was discussed immediately prior to ES6, and since all builtin types (or so we thought, at the time) had a prototype method that brand-checked and threw an exception, this was deemed sufficient for all future types - in other words, a new invariant was added at that time, that every builtin type must have a means by which it can be brand-checked, even if indirectly. The Error types remain the only (overlooked at the time) builtin types for which this does not hold.
 
 ### Breakage
 
-Introduction of symbols.
+Introduction of `Symbol.toStringTag`.
 
 ### Specification Details
 


### PR DESCRIPTION
Re the `Object.prototype.toString` invariant, it was discussed prior to ES6, and since all builtin types (or so we thought, at the time) had a prototype method that brand-checked and threw an exception, this was deemed sufficient for all future types - in other words, a new invariant was added at that time, that every builtin type must have a means by which it can be brand-checked, even if indirectly. The Error types remain the only (overlooked at the time) builtin types for which this does not hold.

^ I'm not sure where to put that, but happy to make a further change if it's helpful.

Separately, I'm not sure i'd call `instanceof` reliable, but prior to Symbol.hasInstance, it functioned as a syntactic method (`x instanceof y`) of effectively doing `Object.getPrototypeOf(x) === y.prototype`.